### PR TITLE
update .markdownlintrc

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,6 +1,11 @@
 {
   "frontMatter": true,
-  "MD002": false,
+  "MD002": {
+    "level": 2
+  },
+  "MD003": {
+    "style": "atx"
+  },
   "MD006": false,
   "MD013": false,
   "MD014": false,


### PR DESCRIPTION
A recent update to [markdownlint](https://github.com/DavidAnson/markdownlint) makes `MD002` (first-header-h1 - First header should be a top level header) configurable so we can require the first header to be an h2 since the h1 is handled by the template.

Also added the standard for `MD003` that we are using across the projects.
